### PR TITLE
mobile view debugging: viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,6 +4,18 @@
     box-sizing: border-box;
 }
 
+:root {
+    --viewport-width: 100vw;
+    --viewport-height: 100vh;
+}
+
+@supports (width: 100dvw) and (height: 100dvh) {
+    :root {
+        --viewport-width: 100dvw;
+        --viewport-height: 100dvh;
+    }
+}
+
 body {
     font-family: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Consolas', 'Courier New', monospace;
     background: black;
@@ -14,8 +26,8 @@ body {
 
 main {
     position: relative;
-    width: 100vw;
-    height: 100vh;
+    width: var(--viewport-width);
+    height: var(--viewport-height);
     margin: 0;
     padding: 0;
     display: block;
@@ -25,8 +37,8 @@ main {
     position: absolute;
     top: 0;
     left: 0;
-    width: 100vw;
-    height: 100vh;
+    width: var(--viewport-width);
+    height: var(--viewport-height);
     background: transparent;
     padding: 0;
     margin: 0;
@@ -35,8 +47,8 @@ main {
 #flowerCanvas {
     background: transparent;
     cursor: crosshair;
-    width: 100vw;
-    height: 100vh;
+    width: var(--viewport-width);
+    height: var(--viewport-height);
     display: block;
 }
 


### PR DESCRIPTION
- Adjusted style.css to drive main, .canvas-container, and #flowerCanvas sizing via dynamic viewport CSS vars, so mobile browsers that expose visual vs. layout viewport differences may not shrink the flower.

- Updated main.js canvas resizing to lock the CSS size to the actual visual viewport, listen to visualViewport resize/scroll events, and scale the internal buffer by device pixel ratio for crisp rendering. WebGL now receives the responsive dimensions directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sync canvas and layout sizing with the visual viewport and scale internal WebGL resolution by device pixel ratio for sharper, stable mobile rendering.
> 
> - **Canvas/WebGL (`main.js`)**:
>   - `resizeCanvas()` now reads `window.visualViewport`, sets CSS pixel size, and scales internal buffer by `devicePixelRatio`; updates GL viewport accordingly.
>   - Centralized resize handling via `handleResize`; listens to window and `visualViewport` `resize`/`scroll`; triggers `updateColors()` when needed.
>   - Updated resize log output to include CSS size and DPR.
> - **Styles (`style.css`)**:
>   - Introduces `--viewport-width/height` with `dvw/dvh` fallback; applies to `main`, `.canvas-container`, and `#flowerCanvas` for accurate viewport sizing on mobile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88715fb7932d3002013a46a5e657acd0e8aa847d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->